### PR TITLE
only add the systemd if the os supports it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Saltstack formula installs and configures MailHog for you.
 
 > **note**
 >
-> This formula has **only been tested on Ubuntu 14.04**.
+> This formula has **only been tested on Ubuntu 14.04 and 16.04**.
 
 ## Changelog
 

--- a/mailhog/install.sls
+++ b/mailhog/install.sls
@@ -1,8 +1,9 @@
-{%- set mailhog_initscript = salt['pillar.get']('mailhog:initscript', 'salt://mailhog/templates/initscript.jinja') %}
-{%- set mailhog_systemdscript = salt['pillar.get']('mailhog:systemdscript', 'salt://mailhog/templates/systemdscript.jinja') %}
 {%- set mailhog_version = salt['pillar.get']('mailhog:version', '0.2.0') %}
 {%- set mailhog_architecture = salt['pillar.get']('mailhog:architecture', 'linux_amd64') %}
 {%- set mailhog_smtp_port = salt['pillar.get']('mailhog:smtp:port', 1025) %}
+{%- set mailhog_initscript = salt['pillar.get']('mailhog:initscript', 'salt://mailhog/templates/initscript.jinja') %}
+{%- set mailhog_systemdscript = salt['pillar.get']('mailhog:systemdscript', 'salt://mailhog/templates/systemdscript.jinja') %}
+{%- set init_system = salt['grains.get']('init', 'upstart') %}
 
 nullmailer:
   pkg.installed: []
@@ -27,7 +28,7 @@ download-mailhog:
     - requires:
       - file: /opt/mailhog
 
-{% if grains['init'] != 'systemd' -%}
+{% if init_system != 'systemd' -%}
 /etc/init.d/mailhog:
   file.managed:
     - source: {{ mailhog_initscript }}
@@ -50,5 +51,4 @@ mailhog:
     - enable: True
     - require:
       - cmd: download-mailhog
-      - file: {% if grains['init'] != 'systemd' -%} /etc/init.d/mailhog {% else %} /lib/systemd/system/mailhog.service {% endif %}
-
+      - file: {% if init_system != 'systemd' -%} /etc/init.d/mailhog {% else %} /lib/systemd/system/mailhog.service {% endif %}

--- a/mailhog/install.sls
+++ b/mailhog/install.sls
@@ -27,6 +27,7 @@ download-mailhog:
     - requires:
       - file: /opt/mailhog
 
+{% if grains['init'] != 'systemd' -%}
 /etc/init.d/mailhog:
   file.managed:
     - source: {{ mailhog_initscript }}
@@ -34,20 +35,20 @@ download-mailhog:
     - mode: 755
     - watch_in:
       - service: mailhog
-
+{% else %}
 /lib/systemd/system/mailhog.service:
   file.managed:
     - source: {{ mailhog_systemdscript }}
     - template: jinja
     - mode: 755
-    - onlyif:
-      - test -d /lib/systemd/system
     - watch_in:
       - service: mailhog
+{% endif %}
 
 mailhog:
   service.running:
     - enable: True
     - require:
       - cmd: download-mailhog
-      - file: /etc/init.d/mailhog
+      - file: {% if grains['init'] != 'systemd' -%} /etc/init.d/mailhog {% else %} /lib/systemd/system/mailhog.service {% endif %}
+


### PR DESCRIPTION
After your comment on #2, I've added some adjustments to only configure the systemd file if the `init` grains state that the machine is using systemd instead of upstart.
